### PR TITLE
Feature/fix bad bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "start": "node lib/index.js",
     "prebuild": "npm run clean && npm run lint",
     "build": "tsc & wait",
-    "pretest": "npm run clean && npm run lint",
+    "pretest": "npm run build",
     "test": "jest --ci --reporters=\"jest-junit\" --coverageReporters=\"cobertura\"",
-    "pretest:local": "npm run clean && npm run lint",
+    "pretest:local": "npm run build",
     "test:local": "jest --watchAll --coverageReporters=\"text\"",
     "prepublishOnly": "npm run test"
   },


### PR DESCRIPTION
# Fix Bad Bundle

## The Following Changes Have Been Made

* Package.json updated so lib is included in a packed npm package

Here's the nature of this bug (it was really stupid of me to be honest). `npm publish` runs `npm test` pre-publish. This is a good thing because it makes sure all tests pass before anything can be put onto npm. The problem with this approach is in `pretest` the `clean` script was running, however the `build` script was not. This made it so lib was cleaned (deleted) and never rebuilt before publishing the package. I never noticed this before as I was locally global installing the package (oops)